### PR TITLE
Add some additional info and debugging code.

### DIFF
--- a/AlphaZero_connect4/src/evaluator_c4.py
+++ b/AlphaZero_connect4/src/evaluator_c4.py
@@ -25,8 +25,11 @@ def save_as_pickle(filename, data):
 def load_pickle(filename):
     completeName = os.path.join("./evaluator_data/",\
                                 filename)
-    with open(completeName, 'rb') as pkl_file:
-        data = pickle.load(pkl_file)
+    try:
+        with open(completeName, 'rb') as pkl_file:
+            data = pickle.load(pkl_file)
+    except Exception as e:
+        logger.error(f"An error occurred in load_pickle for fileName: {completeName}, error: {e}")
     return data
 
 class arena():

--- a/AlphaZero_connect4/src/main_pipeline.py
+++ b/AlphaZero_connect4/src/main_pipeline.py
@@ -41,8 +41,13 @@ if __name__ == "__main__":
     
     logger.info("Starting iteration pipeline...")
     for i in range(args.iteration, args.total_iterations): 
+        logger.info(f'Starting MCTS run {i}...\n')
         run_MCTS(model, args, start_idx=0, iteration=i)
+
+        logger.info(f'Finished MCTS run {i}...\n', 'Starting training')
         train_connectnet(model, args, iteration=i, new_optim_state=True)
+
+        logger.info(f'Finished training {i}...\n', 'Evaluating model...')
         if i >= 1:
             winner = evaluate_nets(model, args, i, i + 1)
             counts = 0


### PR DESCRIPTION
- I noticed during a training run that an evaluation pickle file was not present for one of the 16 CPUs, which caused a terminal error. If some of the game data is not available from one of the CPUs we should just log it and continue training with the available data.

Error: 
Traceback (most recent call last):
  File "main_pipeline.py", line 50, in <module>
    winner = evaluate_nets(model, args, i, i + 1)
  File "/home/shared/omscs-7643-deep-learning-project/AlphaZero_connect4/src/evaluator_c4.py", line 145, in evaluate_nets
    stats = load_pickle("wins_cpu_%i" % (i))
  File "/home/shared/omscs-7643-deep-learning-project/AlphaZero_connect4/src/evaluator_c4.py", line 28, in load_pickle
    with open(completeName, 'rb') as pkl_file:
FileNotFoundError: [Errno 2] No such file or directory: './evaluator_data/wins_cpu_10'
client_loop: send disconnect: Broken pipe